### PR TITLE
Validate exit direction matches room coordinates

### DIFF
--- a/generator/generator.go
+++ b/generator/generator.go
@@ -71,6 +71,12 @@ func Generate(config Config) (*world.Room, error) {
 			continue // Should be rare, but retry if validation fails
 		}
 
+		// Step 4: Validate geometry (exit directions match room coordinates).
+		err = validateGeometry(allRooms)
+		if err != nil {
+			continue // Should be rare; indicates a builder regression
+		}
+
 		// If we get here, the world is valid.
 		return startRoom, nil
 	}

--- a/generator/validator.go
+++ b/generator/validator.go
@@ -2,6 +2,7 @@ package generator
 
 import (
 	"errors"
+	"fmt"
 	"text-adventure-v2/world"
 )
 
@@ -45,6 +46,35 @@ func validateWorld(startRoom *world.Room, allRooms map[string]*world.Room) error
 		return errors.New("validator: a path to treasure exists without needing the key")
 	}
 
+	return nil
+}
+
+// validateGeometry checks that each exit's target room coordinates match the direction label:
+// "east" must point to (X+1, Y), "south" to (X, Y+1), and so on. The renderer draws corridors
+// from these coordinates; a mismatch renders as a room with no visible connection. The builder
+// upholds this by construction — this guard catches regressions.
+func validateGeometry(allRooms map[string]*world.Room) error {
+	for _, room := range allRooms {
+		for dir, exit := range room.Exits {
+			var dx, dy int
+			switch dir {
+			case "north":
+				dx, dy = 0, -1
+			case "south":
+				dx, dy = 0, 1
+			case "east":
+				dx, dy = 1, 0
+			case "west":
+				dx, dy = -1, 0
+			default:
+				return fmt.Errorf("validator: room %q has unknown exit direction %q", room.Name, dir)
+			}
+			if exit.Room.X != room.X+dx || exit.Room.Y != room.Y+dy {
+				return fmt.Errorf("validator: room %q %s exit points to %q at (%d,%d), expected (%d,%d)",
+					room.Name, dir, exit.Room.Name, exit.Room.X, exit.Room.Y, room.X+dx, room.Y+dy)
+			}
+		}
+	}
 	return nil
 }
 

--- a/generator/validator_test.go
+++ b/generator/validator_test.go
@@ -176,6 +176,127 @@ func TestValidatorBfs_SameRoom(t *testing.T) {
 	}
 }
 
+// --- validateGeometry tests ---
+
+func TestValidateGeometry_ValidDirections(t *testing.T) {
+	cases := []struct {
+		name   string
+		dir    string
+		dx, dy int
+		back   string
+	}{
+		{"east", "east", 1, 0, "west"},
+		{"west", "west", -1, 0, "east"},
+		{"south", "south", 0, 1, "north"},
+		{"north", "north", 0, -1, "south"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			a := &world.Room{Name: "A", Exits: make(map[string]*world.Exit), X: 0, Y: 0}
+			b := &world.Room{Name: "B", Exits: make(map[string]*world.Exit), X: c.dx, Y: c.dy}
+			a.Exits[c.dir] = &world.Exit{Room: b}
+			b.Exits[c.back] = &world.Exit{Room: a}
+
+			allRooms := map[string]*world.Room{"A": a, "B": b}
+
+			if err := validateGeometry(allRooms); err != nil {
+				t.Errorf("Expected valid %s exit, got error: %v", c.dir, err)
+			}
+		})
+	}
+}
+
+func TestValidateGeometry_WrongCoordsPerDirection(t *testing.T) {
+	cases := []struct {
+		name   string
+		dir    string
+		bx, by int // incorrect coords for B
+	}{
+		{"east points two steps away", "east", 2, 0},
+		{"west points two steps away", "west", -2, 0},
+		{"south points two steps away", "south", 0, 2},
+		{"north points two steps away", "north", 0, -2},
+		{"east has drifted on Y axis", "east", 1, 1},
+		{"south has drifted on X axis", "south", 1, 1},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			a := &world.Room{Name: "A", Exits: make(map[string]*world.Exit), X: 0, Y: 0}
+			b := &world.Room{Name: "B", Exits: make(map[string]*world.Exit), X: c.bx, Y: c.by}
+			a.Exits[c.dir] = &world.Exit{Room: b}
+
+			allRooms := map[string]*world.Room{"A": a, "B": b}
+
+			if err := validateGeometry(allRooms); err == nil {
+				t.Fatalf("Expected error for %s exit pointing to (%d,%d), got nil", c.dir, c.bx, c.by)
+			}
+		})
+	}
+}
+
+func TestValidateGeometry_UnknownDirection(t *testing.T) {
+	a := &world.Room{Name: "A", Exits: make(map[string]*world.Exit), X: 0, Y: 0}
+	b := &world.Room{Name: "B", Exits: make(map[string]*world.Exit), X: 0, Y: 0}
+	a.Exits["up"] = &world.Exit{Room: b}
+
+	allRooms := map[string]*world.Room{"A": a, "B": b}
+
+	if err := validateGeometry(allRooms); err == nil {
+		t.Fatal("Expected error for unknown direction, got nil")
+	}
+}
+
+func TestValidateGeometry_MultiRoomChain(t *testing.T) {
+	// 4 rooms in a line: A(0,0) <-> B(1,0) <-> C(2,0) <-> D(3,0)
+	a := &world.Room{Name: "A", Exits: make(map[string]*world.Exit), X: 0, Y: 0}
+	b := &world.Room{Name: "B", Exits: make(map[string]*world.Exit), X: 1, Y: 0}
+	c := &world.Room{Name: "C", Exits: make(map[string]*world.Exit), X: 2, Y: 0}
+	d := &world.Room{Name: "D", Exits: make(map[string]*world.Exit), X: 3, Y: 0}
+
+	a.Exits["east"] = &world.Exit{Room: b}
+	b.Exits["west"] = &world.Exit{Room: a}
+	b.Exits["east"] = &world.Exit{Room: c}
+	c.Exits["west"] = &world.Exit{Room: b}
+	c.Exits["east"] = &world.Exit{Room: d}
+	d.Exits["west"] = &world.Exit{Room: c}
+
+	allRooms := map[string]*world.Room{"A": a, "B": b, "C": c, "D": d}
+
+	if err := validateGeometry(allRooms); err != nil {
+		t.Errorf("Expected valid multi-room chain, got error: %v", err)
+	}
+}
+
+func TestValidateGeometry_SameCoordinates(t *testing.T) {
+	// Two rooms at (0,0) with an east exit between them — impossible geometry.
+	a := &world.Room{Name: "A", Exits: make(map[string]*world.Exit), X: 0, Y: 0}
+	b := &world.Room{Name: "B", Exits: make(map[string]*world.Exit), X: 0, Y: 0}
+	a.Exits["east"] = &world.Exit{Room: b}
+
+	allRooms := map[string]*world.Room{"A": a, "B": b}
+
+	if err := validateGeometry(allRooms); err == nil {
+		t.Fatal("Expected error for two rooms at same coordinates with a directional exit, got nil")
+	}
+}
+
+func TestValidateGeometry_PartiallyInvalid(t *testing.T) {
+	// 3 rooms, first two correctly wired, third at bad coords.
+	a := &world.Room{Name: "A", Exits: make(map[string]*world.Exit), X: 0, Y: 0}
+	b := &world.Room{Name: "B", Exits: make(map[string]*world.Exit), X: 1, Y: 0}
+	bad := &world.Room{Name: "Bad", Exits: make(map[string]*world.Exit), X: 5, Y: 5}
+
+	a.Exits["east"] = &world.Exit{Room: b}
+	b.Exits["west"] = &world.Exit{Room: a}
+	b.Exits["east"] = &world.Exit{Room: bad} // expected (2,0), got (5,5)
+
+	allRooms := map[string]*world.Room{"A": a, "B": b, "Bad": bad}
+
+	if err := validateGeometry(allRooms); err == nil {
+		t.Fatal("Expected error when one of three rooms has bad coordinates, got nil")
+	}
+}
+
 func TestValidatorBfs_MultiHopPath(t *testing.T) {
 	a := &world.Room{Name: "A", Exits: make(map[string]*world.Exit)}
 	b := &world.Room{Name: "B", Exits: make(map[string]*world.Exit)}


### PR DESCRIPTION
## Summary
- Add `validateGeometry` to `generator/validator.go` — checks each exit's target room coordinates match the direction label (east → X+1, south → Y+1, etc.) so the renderer never silently drops a corridor
- Wire into `Generate()` as Step 4, after `validateWorld` succeeds
- Six new test functions covering success per direction (table-driven), failure per direction (table-driven), unknown directions, multi-room chains, same-coordinate collision, and partial mismatch

## Test plan
- [ ] `go test ./generator/...` passes (12 new test cases + 21 existing)
- [ ] `go build ./...` succeeds
- [ ] `go run .` still plays normally (runtime behavior unchanged for valid worlds)

🤖 Generated with [Claude Code](https://claude.com/claude-code)