### PR TITLE
[reviewer-pilot] replay 29226e8: Fix keyboard interception + biased room generation

### DIFF
--- a/generator/builder.go
+++ b/generator/builder.go
@@ -37,11 +37,11 @@ func buildWorld(config Config) (*world.Room, map[string]*world.Room, error) {
 		var created bool
 		for !created {
 			// Pick a random existing room to branch off from
-			var randomRoom *world.Room
+			roomList := make([]*world.Room, 0, len(allRooms))
 			for _, r := range allRooms {
-				randomRoom = r
-				break
+				roomList = append(roomList, r)
 			}
+			randomRoom := roomList[rand.Intn(len(roomList))]
 
 			// Pick a random direction
 			dirs := []string{"north", "south", "east", "west"}

--- a/main.go
+++ b/main.go
@@ -89,11 +89,15 @@ func main() {
 					inputStr = inputStr[:len(inputStr)-1]
 				}
 			case tcell.KeyRune:
-				// Only if not a special command (w,a,s,d,e,i,u,h,q)
-				switch ev.Rune() {
-				case 'w', 'a', 's', 'd', 'e', 'i', 'u', 'h', 'q':
-					command = string(ev.Rune())
-				default:
+				// Only intercept instant commands when not mid-typing
+				if inputStr == "" {
+					switch ev.Rune() {
+					case 'w', 'a', 's', 'd', 'e', 'i', 'u', 'h', 'q':
+						command = string(ev.Rune())
+					default:
+						inputStr += string(ev.Rune())
+					}
+				} else {
 					inputStr += string(ev.Rune())
 				}
 			}


### PR DESCRIPTION
Throwaway replay to exercise the AI reviewers (ours + Greptile) on real historical code. Will be CLOSED unmerged and both branches deleted after harvest. Original commit 29226e8 on main.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR delivers two independent bug fixes: proper uniform random room selection in the world generator, and correct keyboard hotkey interception in the main game loop.

- **`generator/builder.go`**: The old code took the first map entry (non-uniform due to Go's randomized map iteration) as the \"random\" parent room. The fix collects all rooms into a slice and uses `rand.Intn` for a true uniform draw. The `roomList` slice is currently rebuilt inside the `for !created` retry loop even though `allRooms` is stable between retries — moving it above the retry loop would avoid redundant allocations on dense-grid failures.
- **`main.go`**: Previously, single-letter hotkeys (`w`, `a`, `s`, `d`, etc.) were intercepted unconditionally, meaning pressing `w` mid-typing would fire \"go west\" instead of appending to the input string. The fix gates hotkey dispatch behind `inputStr == \"\"`, so hotkeys only fire from an idle prompt while typed commands work normally.

<h3>Confidence Score: 4/5</h3>

Both fixes are isolated, correct, and address clear bugs in room generation and keyboard handling with minimal risk

The room generation now uses proper random selection via slice indexing instead of the first map entry, eliminating the non-uniform bias. The keyboard handler correctly gates hotkey interception behind an empty input buffer, so typed commands no longer trigger movement mid-input. The only noted inefficiency is rebuilding the room candidate slice on each placement retry rather than once per room, but this affects performance on dense grids rather than correctness.

The room list allocation pattern in builder.go could be hoisted above the retry loop for efficiency but does not affect correctness

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| generator/builder.go | Replaces non-uniform map-iteration room selection with a proper slice+rand.Intn pick, correctly fixing biased generation. Minor inefficiency: the candidate slice is rebuilt on every retry inside the inner loop. |
| main.go | Gates single-key hotkey interception behind inputStr == "" so hotkeys no longer fire mid-typing; logic is correct and handles all key states cleanly. |

</details>

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[KeyRune Event] --> B{inputStr == empty?}
    B -- Yes --> C{Rune is hotkey?\nw/a/s/d/e/i/u/h/q}
    C -- Yes --> D[command = rune\ninstant dispatch]
    C -- No --> E[inputStr += rune]
    B -- No --> F[inputStr += rune\nappend to buffer]
    D --> G[g.HandleCommand]
    G --> H{shouldExit?}
    H -- Yes --> I[Show end screen\nwait for key → return]
    H -- No --> J[message = result\nredraw loop]
    E --> J
    F --> J
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[KeyRune Event] --> B{inputStr == empty?}
    B -- Yes --> C{Rune is hotkey?\nw/a/s/d/e/i/u/h/q}
    C -- Yes --> D[command = rune\ninstant dispatch]
    C -- No --> E[inputStr += rune]
    B -- No --> F[inputStr += rune\nappend to buffer]
    D --> G[g.HandleCommand]
    G --> H{shouldExit?}
    H -- Yes --> I[Show end screen\nwait for key → return]
    H -- No --> J[message = result\nredraw loop]
    E --> J
    F --> J
```

</a>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Agenerator%2Fbuilder.go%3A37-44%0A**Room%20list%20rebuilt%20on%20every%20retry%20attempt**%0A%0A%60roomList%60%20is%20reconstructed%20inside%20%60for%20!created%60%2C%20but%20%60allRooms%60%20never%20changes%20between%20retries%20%E2%80%94%20a%20new%20room%20is%20only%20added%20when%20%60created%20%3D%20true%60%2C%20which%20immediately%20exits%20the%20inner%20loop.%20Moving%20the%20slice%20build%20to%20just%20before%20the%20%60for%20!created%60%20loop%20would%20avoid%20redundant%20O%28n%29%20allocations%20on%20each%20failed%20placement%20attempt%20%28which%20can%20be%20frequent%20in%20dense%20grids%29.%0A%0A&repo=kphutt%2Ftext-adventure-v2&pr=3&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["Fix keyboard interception during typing ..."](https://github.com/kphutt/text-adventure-v2/commit/29226e8665aac14c3453e5d3090a5a9613d47848) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39441978)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->