### PR TITLE
docs: fix stale CLAUDE.md heading in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,4 @@
-# CLAUDE.md
+# text-adventure-v2 — contributor & AI-agent guide
 
 ## Project
 Terminal-based text adventure game in Go with procedurally generated worlds.


### PR DESCRIPTION
Renames the top heading from `# CLAUDE.md` to `# text-adventure-v2 — contributor & AI-agent guide`. Per house convention the contributor guide is always named AGENTS.md, so the `# CLAUDE.md` heading was stale. No other changes.
