### PR TITLE
chore: point AGENTS.md at the shared cross-repo conventions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,7 @@
 # text-adventure-v2 — contributor & AI-agent guide
 
+> Cross-repo conventions (fleet-wide) live in `~/dev/AGENTS.md` — the sole authority for anything fleet-wide. This file holds only text-adventure-v2-specific guidance.
+
 ## Project
 Terminal-based text adventure game in Go with procedurally generated worlds.
 


### PR DESCRIPTION
Adds a blockquote pointer directly under the H1 in AGENTS.md directing agents to `~/dev/AGENTS.md` as the sole authority for fleet-wide conventions. Purely additive — no existing content changed.
