### PR TITLE
Add CLAUDE.md bridge (@AGENTS.md) so Claude reads the repo's conventions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md


### PR DESCRIPTION
Adds a one-line root `CLAUDE.md` (`@AGENTS.md`) so **Claude Code** loads this repo's own conventions.

**Why:** Claude reads `CLAUDE.md`, not `AGENTS.md`. `agy`/Antigravity reads `AGENTS.md` natively; Claude needs this bridge. `@import` is Anthropic's official pattern — `AGENTS.md` stays the single source, no duplication. Public-safe (one line, no content).

Part of the fleet-wide per-repo bridge.
